### PR TITLE
feat: linux compatibility

### DIFF
--- a/async.js
+++ b/async.js
@@ -9,7 +9,7 @@ process.on('uncaughtException', error => {
 
 const CHUNK_SIZE = 32 * 1024;
 
-const client = net.connect(`\\\\?\\pipe\\loot-ipc-${process.argv[2]}`, (arg) => {
+const client = net.connect(process.argv[2], (arg) => {
   let instance;
   let dataBuffer = '';
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -21,9 +21,6 @@
                 "./loot_api/include",
                 "<!(node -p \"require('node-addon-api').include_dir\")"
             ],
-            "libraries": [
-                "-l../loot_api/loot"
-            ],
             'cflags!': ['-fno-exceptions', '-g', '-O0'],
             'cflags_cc!': ['-fno-exceptions'],
             'msvs_settings': {
@@ -49,6 +46,7 @@
                   "WINVER=0x600"
                 ],
                 "libraries": [
+                  "-l../loot_api/loot",
                   "-DelayLoad:node.exe",
                 ],
                 'msvs_settings': {
@@ -59,6 +57,17 @@
                     'LinkTimeCodeGeneration': 1
                   }
                 }
+              }],
+              ["OS=='linux'", {
+                "cflags_cc": [
+                  "-std=c++20"
+                ],
+                "ldflags": [
+                  "-Wl,-rpath,\\$$ORIGIN/../../loot_api"
+                ],
+                "libraries": [
+                  "<(module_root_dir)/loot_api/libloot.so.0"
+                ]
               }]
             ]
         }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "node-loot linux build shell";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }: let
+    system = "x86_64-linux";
+    pkgs = import nixpkgs { inherit system; };
+  in {
+    devShells.${system}.default = pkgs.mkShell {
+      packages = with pkgs; [
+        nodejs_24
+        yarn
+        python3
+        gnumake
+        gcc
+        pkg-config
+        patchelf
+      ];
+
+      shellHook = ''
+        export CC=${pkgs.gcc}/bin/gcc
+        export CXX=${pkgs.gcc}/bin/g++
+        # Only add project-local lib dir; avoid overriding libstdc++ for node itself.
+        export LD_LIBRARY_PATH="$PWD/loot_api''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+      '';
+    };
+  };
+}

--- a/index.js
+++ b/index.js
@@ -1,9 +1,33 @@
-net = require('net');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
 const path = require('path');
 
 const { Loot, IsCompatible } = require('./build/Release/node-loot');
 
 const CHUNK_SIZE = 32 * 1024;
+
+function getIpcPath(id) {
+  if (process.platform === 'win32') {
+    return `\\\\?\\pipe\\loot-ipc-${id}`;
+  }
+
+  return path.join(os.tmpdir(), `loot-ipc-${id}.sock`);
+}
+
+function cleanupIpcPath(ipcPath) {
+  if (process.platform === 'win32') {
+    return;
+  }
+
+  try {
+    fs.unlinkSync(ipcPath);
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw err;
+    }
+  }
+}
 
 // interface IPluginsNotLoadedArgs {
 //   name: string;
@@ -104,11 +128,13 @@ class LootAsync {
     this.makeProxy('getGeneralMessages');
 
     this.id = this.generateId();
+    this.ipcPath = getIpcPath(this.id);
     this.ipc = new net.Server();
     try {
       // this seems to fail for some users with EINVAL. why?
       // May be a wine-only problem but that's not confirmed
-      this.ipc.listen(`\\\\?\\pipe\\loot-ipc-${this.id}`, () => {
+      cleanupIpcPath(this.ipcPath);
+      this.ipc.listen(this.ipcPath, () => {
         this.ipc.on('connection', socket => {
           this.socket = socket;
           socket
@@ -148,12 +174,12 @@ class LootAsync {
         initCallback(err);
       });
     } catch (err) {
-      initCallback(new Error('failed to establish pipe'));
+      initCallback(new Error('failed to establish IPC endpoint'));
     }
   }
 
   restart(callback) {
-    this.worker = this.onFork(`${__dirname}${path.sep}async.js`, [this.id]);
+    this.worker = this.onFork(`${__dirname}${path.sep}async.js`, [this.ipcPath]);
     this.currentCallback = () => {
       this.enqueue({
         type: 'init',
@@ -172,8 +198,18 @@ class LootAsync {
   }
 
   close() {
+    if (this.didClose) {
+      return;
+    }
+
     this.enqueue({ type: 'terminate' }, () => {
       this.worker = undefined;
+      if (this.ipc) {
+        this.ipc.close(() => cleanupIpcPath(this.ipcPath));
+        this.ipc = undefined;
+      } else {
+        cleanupIpcPath(this.ipcPath);
+      }
     });
     this.didClose = true;
   }

--- a/src/exceptions.cpp
+++ b/src/exceptions.cpp
@@ -4,7 +4,7 @@
 #include <napi.h>
 #include <optional>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 
 std::wstring strerror(unsigned long errorno) {
@@ -31,11 +31,11 @@ std::wstring strerror(unsigned long errorno) {
   }
 }
 
-#endif // WIN32
+#endif // _WIN32
 
 Napi::Error ErrnoException(const Napi::Env &env, unsigned long lastError, const char * func, const char * path) {
 
-#ifdef WIN32
+#ifdef _WIN32
   std::wstring errStr = strerror(lastError);
   std::string err = toMB(errStr.c_str(), CodePage::UTF8, errStr.size());
 #else

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -1,9 +1,9 @@
 #pragma once
 
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
-#endif // WIN32
+#endif // _WIN32
 #include <exception>
 #include <napi.h>
 #include <loot/api.h>

--- a/src/lootwrapper.cpp
+++ b/src/lootwrapper.cpp
@@ -7,7 +7,7 @@
 #include <memory>
 #include <iostream>
 #include <clocale>
-#ifdef WIN32
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
@@ -136,7 +136,11 @@ Loot::Loot(const Napi::CallbackInfo &info)
   , m_LogCallback(Napi::ThreadSafeFunction::New(info.Env(), info[4].As<Napi::Function>(), "logcb", 0, 1))
 {
   std::string game, language;
+#ifdef _WIN32
   std::wstring gamePath, gameLocalPath;
+#else
+  std::string gamePath, gameLocalPath;
+#endif
   unpackArgs(info, game, gamePath, gameLocalPath, language);
 
   m_Language = language;
@@ -177,7 +181,11 @@ Napi::Value Loot::loadLists(const Napi::CallbackInfo &info) {
    * loadMasterlist, loadMasterlistWithPrelude and loadUserlist.
    * We're going to consolidate both calls in this function for now.
   */
+#ifdef _WIN32
   std::wstring masterlistPath, userlistPath, preludePath;
+#else
+  std::string masterlistPath, userlistPath, preludePath;
+#endif
   unpackArgs(info, masterlistPath, userlistPath, preludePath);
 
   try {
@@ -222,8 +230,6 @@ Napi::Value Loot::getPluginMetadata(const Napi::CallbackInfo &info) {
   unpackArgs<1>(info, pluginName, includeUserMetadata, evaluateConditions);
 
   try {
-    Napi::Value res = Napi::Object::New(info.Env());
-
     std::optional<loot::PluginMetadata> meta = m_Game->GetDatabase().GetPluginMetadata(pluginName, includeUserMetadata, evaluateConditions);
     if (meta.has_value()) {
       // previously throw an exception here but this is *not* an error, it happens for all plugins
@@ -305,6 +311,8 @@ Napi::Value Loot::sortPlugins(const Napi::CallbackInfo &info) {
   } catch (const std::exception &e) {
     throw LOOTError(info.Env(), "sortPlugins", e.what());
   }
+
+  return info.Env().Undefined();
 }
 
 Napi::Value Loot::setLoadOrder(const Napi::CallbackInfo &info) {
@@ -401,7 +409,7 @@ Napi::Value Loot::getGeneralMessages(const Napi::CallbackInfo &info) {
 }
 
 Napi::Value SetErrorLanguageEN(const Napi::CallbackInfo &info) {
-#ifdef WIN32
+#ifdef _WIN32
   ULONG count = 1;
   WCHAR wszLanguages[32];
   wsprintfW(wszLanguages, L"%04X%c", MAKELANGID(LANG_ENGLISH, SUBLANG_DEFAULT), 0);

--- a/src/napi_helpers.h
+++ b/src/napi_helpers.h
@@ -91,6 +91,7 @@ void convertArg<std::string>(Tag<std::string>, std::string &out, const Napi::Cal
   out = fromNAPI<std::string>(info[idx]);
 }
 
+#ifdef _WIN32
 template<>
 void convertArg<std::wstring>(Tag<std::wstring>, std::wstring &out, const Napi::CallbackInfo &info, int idx) {
   if (!info[idx].IsString()) {
@@ -99,6 +100,7 @@ void convertArg<std::wstring>(Tag<std::wstring>, std::wstring &out, const Napi::
   out = fromNAPI<std::wstring>(info[idx]);
 }
 
+#endif
 template<>
 void convertArg<bool>(Tag<bool>, bool &out, const Napi::CallbackInfo &info, int idx) {
   if (!info[idx].IsBoolean()) {
@@ -126,7 +128,7 @@ void convertArg(Tag<std::vector<T>>, std::vector<T> &out, const Napi::CallbackIn
 
 template<size_t I = 0, typename T0, typename... TR>
 void convertRec(const Napi::CallbackInfo &info, int requiredCount, T0 &out, TR &... rest) {
-  if ((requiredCount > I) || (info.Length() > I)) {
+  if (((requiredCount > 0) && (static_cast<size_t>(requiredCount) > I)) || (info.Length() > I)) {
     convertArg(Tag<T0>(), out, info, I);
   }
   if constexpr (sizeof...(rest) > 0) {

--- a/src/string_cast.cpp
+++ b/src/string_cast.cpp
@@ -1,6 +1,6 @@
 #include "string_cast.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 
 #define WIN32_LEAN_AND_MEAN
 #define _WINSOCKAPI_
@@ -81,7 +81,7 @@ std::wstring u8Tou16(const std::string & input) {
   return toWC(input.c_str(), CodePage::UTF8, input.length());
 }
 
-#else // WIN32
+#else // _WIN32
 std::string toWC(const char * const &source, CodePage codePage, size_t sourceLength) {
   return source;
 }


### PR DESCRIPTION
* tweaks to build and run natively on linux
* some small linter/warning fixes
* flake.nix for dev shell

Don't have Windows to verify that I didn't break that build, though.

I used this flake.nix to build `libloot.so.0` v0.27.0 from https://github.com/loot/libloot:

```nix
{
  description = "Nix flake for building libloot (shared library)";

  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
  };

  outputs = { self, nixpkgs }:
    let
      lib = nixpkgs.lib;
      forAllSystems = lib.genAttrs [ "x86_64-linux" "aarch64-linux" ];
    in {
      packages = forAllSystems (system:
        let
          pkgs = import nixpkgs { inherit system; };

          espluginTarball = pkgs.fetchurl {
            url = "https://github.com/Ortham/esplugin/archive/refs/tags/6.1.3.tar.gz";
            hash = "sha256-0RNzuRCANujYRT/3cACuKWH50SQ8mcQt1zLa0Mg9hhg=";
          };

          libloadorderTarball = pkgs.fetchurl {
            url = "https://github.com/Ortham/libloadorder/archive/refs/tags/18.4.0.tar.gz";
            hash = "sha256-yD8fSIKeAT8mNAQbYv7YxJV/t0aaQBJQs3k5U+08PSw=";
          };

          lootConditionInterpreterTarball = pkgs.fetchurl {
            url = "https://github.com/loot/loot-condition-interpreter/archive/refs/tags/5.3.2.tar.gz";
            hash = "sha256-EaLGKJj2RQza5ttgfGP9eJj2K/Z9SHS3zu09NpMzGvM=";
          };

          yamlCppTarball = pkgs.fetchurl {
            url = "https://github.com/loot/yaml-cpp/archive/0.8.0+merge-key-support.3.tar.gz";
            hash = "sha256-4gZ/Grj2WK64qHlf0OBqdTtBULk1LK4EcoDmWQeN1E8=";
          };

          mkSource = name: tarball:
            pkgs.runCommand "${name}-source" { } ''
              mkdir -p "$out"
              tar -xzf ${tarball} --strip-components=1 -C "$out"
            '';

          mkFfiRustLibrary = {
            pname,
            version,
            src,
            cargoLockFile,
            manifestPath,
            staticLibName,
            cbindgenDir,
            cbindgenOutput,
            cbindgenArgs ? "",
          }:
            pkgs.rustPlatform.buildRustPackage {
              inherit pname version src;
              cargoLock.lockFile = cargoLockFile;
              cargoBuildFlags = [ "--manifest-path" manifestPath ];
              nativeBuildInputs = [ pkgs.rust-cbindgen ];
              doCheck = false;

              installPhase = ''
                runHook preInstall

                mkdir -p "$out/lib" "$out/include"
                staticLibPath=$(find target -type f -name "${staticLibName}" | head -n1)
                cp "$staticLibPath" "$out/lib/"
                cbindgen ${cbindgenArgs} ${cbindgenDir}/ -o "$out/include/${cbindgenOutput}"

                runHook postInstall
              '';
            };

          espluginSource = mkSource "esplugin-6.1.3" espluginTarball;
          libloadorderSource = mkSource "libloadorder-18.4.0" libloadorderTarball;
          lootConditionInterpreterSource = mkSource "loot-condition-interpreter-5.3.2" lootConditionInterpreterTarball;
          yamlCppSource = mkSource "yaml-cpp-0.8.0-merge-key-support.3" yamlCppTarball;

          espluginFfi = mkFfiRustLibrary {
            pname = "esplugin-ffi";
            version = "6.1.3";
            src = espluginSource;
            cargoLockFile = "${espluginSource}/Cargo.lock";
            manifestPath = "ffi/Cargo.toml";
            staticLibName = "libesplugin_ffi.a";
            cbindgenDir = "ffi";
            cbindgenOutput = "esplugin.hpp";
          };

          libloadorderFfi = mkFfiRustLibrary {
            pname = "libloadorder-ffi";
            version = "18.4.0";
            src = libloadorderSource;
            cargoLockFile = "${libloadorderSource}/Cargo.lock";
            manifestPath = "ffi/Cargo.toml";
            staticLibName = "libloadorder_ffi.a";
            cbindgenDir = "ffi";
            cbindgenOutput = "libloadorder.hpp";
            cbindgenArgs = "-l c++";
          };

          lootConditionInterpreterFfi = mkFfiRustLibrary {
            pname = "loot-condition-interpreter-ffi";
            version = "5.3.2";
            src = lootConditionInterpreterSource;
            cargoLockFile = "${lootConditionInterpreterSource}/Cargo.lock";
            manifestPath = "ffi/Cargo.toml";
            staticLibName = "libloot_condition_interpreter_ffi.a";
            cbindgenDir = "ffi";
            cbindgenOutput = "loot_condition_interpreter.h";
          };

          liblootPkg = pkgs.stdenv.mkDerivation {
            pname = "libloot";
            version = "0.27.0";

            src = ./.;
            strictDeps = true;
            preferLocalBuild = true;

            nativeBuildInputs = with pkgs; [
              cmake
              ninja
              pkg-config
              git
              python3
            ];

            buildInputs = with pkgs; [
              boost
              icu
              tbb
              fmt
              spdlog
            ];

            postPatch = ''
              python - <<'PY'
              from pathlib import Path

              path = Path("CMakeLists.txt")
              text = path.read_text()

              replacements = [
                  (
                      "if(NOT DEFINED ESPLUGIN_URL)",
                      "if(NOT (DEFINED ESPLUGIN_INCLUDE_DIRS AND DEFINED ESPLUGIN_LIBRARIES))\nif(NOT DEFINED ESPLUGIN_URL)",
                  ),
                  (
                      "if(NOT DEFINED LIBLOADORDER_URL)",
                      "endif()\n\nif(NOT (DEFINED LIBLOADORDER_INCLUDE_DIRS AND DEFINED LIBLOADORDER_LIBRARIES))\nif(NOT DEFINED LIBLOADORDER_URL)",
                  ),
                  (
                      "if(NOT DEFINED LOOT_CONDITION_INTERPRETER_URL)",
                      "endif()\n\nif(NOT (DEFINED LCI_INCLUDE_DIRS AND DEFINED LCI_LIBRARIES))\nif(NOT DEFINED LOOT_CONDITION_INTERPRETER_URL)",
                  ),
                  (
                      "FetchContent_Declare(\n    fmt",
                      "endif()\n\nFetchContent_Declare(\n    fmt",
                  ),
                  (
                      "add_dependencies(loot\n    esplugin\n    libloadorder\n    loot-condition-interpreter)",
                      "if(TARGET esplugin)\n    add_dependencies(loot esplugin)\nendif()\nif(TARGET libloadorder)\n    add_dependencies(loot libloadorder)\nendif()\nif(TARGET loot-condition-interpreter)\n    add_dependencies(loot loot-condition-interpreter)\nendif()",
                  ),
              ]

              for old, new in replacements:
                  if old not in text:
                      raise SystemExit(f"Patch pattern not found: {old!r}")
                  text = text.replace(old, new, 1)

              path.write_text(text)
              PY
            '';

            cmakeFlags = [
              "-DCMAKE_BUILD_TYPE=Release"
              "-DBUILD_SHARED_LIBS=ON"
              "-DLIBLOOT_BUILD_TESTS=OFF"
              "-DLIBLOOT_INSTALL_DOCS=OFF"

              "-DESPLUGIN_INCLUDE_DIRS=${espluginFfi}/include"
              "-DESPLUGIN_LIBRARIES=${espluginFfi}/lib/libesplugin_ffi.a;dl"

              "-DLIBLOADORDER_INCLUDE_DIRS=${libloadorderFfi}/include"
              "-DLIBLOADORDER_LIBRARIES=${libloadorderFfi}/lib/libloadorder_ffi.a;dl"

              "-DLCI_INCLUDE_DIRS=${lootConditionInterpreterFfi}/include"
              "-DLCI_LIBRARIES=${lootConditionInterpreterFfi}/lib/libloot_condition_interpreter_ffi.a;dl"

              "-DFETCHCONTENT_SOURCE_DIR_YAML-CPP=${yamlCppSource}"
            ];

            meta = with pkgs.lib; {
              description = "libloot shared library";
              homepage = "https://github.com/loot/libloot";
              license = licenses.gpl3Only;
              platforms = platforms.linux;
            };
          };
        in {
          libloot = liblootPkg;
          default = liblootPkg;
        });

      devShells = forAllSystems (system:
        let
          pkgs = import nixpkgs { inherit system; };
        in {
          default = pkgs.mkShell {
            packages = with pkgs; [
              cmake
              ninja
              pkg-config
              git
              rustc
              cargo
              rust-cbindgen
              boost
              icu
              tbb
              fmt
              spdlog
            ];
          };
        });
    };
}
```

That bit definitely seems over-complicated, probably simpler to use docker or their github actions. :)